### PR TITLE
Add tests & add highWaterMark support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,15 @@ module.exports = BatchStream;
 
 function BatchStream (options) {
   options || (options = {});
-  stream.Transform.call(this, { objectMode : true });
+
+  var transformOptions = {
+    objectMode: true
+  }
+  if(options.highWaterMark) {
+    transformOptions.highWaterMark = options.highWaterMark
+  }
+
+  stream.Transform.call(this, transformOptions);
   this.size  = options.size || 100;
   this.batch = [];
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/segmentio/batch-stream/issues"
+  },
+  "devDependencies": {
+    "mocha": "^1.19.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,71 @@
+var assert = require('assert')
+var Batch = require('../lib')
+
+var stream = require('stream')
+var util = require('util')
+
+var FakeStream = function(array, options) {
+  stream.Readable.call(this, options)
+  this.array = array
+}
+
+util.inherits(FakeStream, stream.Readable)
+
+FakeStream.prototype._read = function() {
+  var item = this.array.shift()
+  if(item instanceof Error) {
+    throw item
+  }
+  setImmediate(function() {
+    this.push(item)
+  }.bind(this))
+}
+
+
+describe('basic functionality', function() {
+
+  it('batches if source lenght is less than batch size', function(done) {
+    var fake = new FakeStream(['one', 'two'])
+    var batch = new Batch({size: 20})
+    fake.pipe(batch)
+    batch.once('readable', function() {
+      var out = batch.read()
+      assert.equal(out.length, 2)
+      assert.equal(out[0], 'one')
+      assert.equal(out[1], 'two')
+      batch.once('end', done)
+    })
+  })
+
+  it('batches if source lenght is greater than batch size', function(done) {
+    var fake = new FakeStream([1, 2, {name: 'Brian'}], {objectMode: true})
+    var batch = new Batch({size: 2})
+    fake.pipe(batch)
+    batch.once('readable', function() {
+      var out = batch.read()
+      assert.equal(out.length, 2)
+      assert.equal(out[0], 1)
+      assert.equal(out[1], 2)
+      batch.once('readable', function() {
+        var out = batch.read()
+        assert.equal(out.length, 1)
+        assert.equal(out[0].name, 'Brian')
+        done()
+      })
+    })
+  })
+
+  it('applies back pressure correctly', function(done) {
+    var fake = new FakeStream([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, new Error('Should not get here')], {objectMode: true})
+    var batch = new Batch({size: 2, highWaterMark: 2})
+    fake.pipe(batch)
+    batch.once('readable', function() {
+      assert.equal(batch.read().length, 2)
+      batch.once('readable', function() {
+        assert.equal(batch.read().length, 2)
+        done()
+      })
+    })
+  })
+
+})


### PR DESCRIPTION
I ran into an issue where I was doing something like this:

``` js
queryStream.pipe(batchStream).pipe(slowWriter)
```

The query stream was streaming 20 million rows into a slow writer.  Because batch-stream doesn't set a highWaterMark it ends up slurping so many rows into memory that the process eventually hits the v8 heap limit and starts thrashing on GC really, really hard. :frowning: 

Another way to reproduce this is like so:

``` js
var Readable = require('stream').Readable
var Writable = require('stream').Writable
var Batch = require('batch-stream')

var readable = new Readable({objectMode: true})
var val = 0

readable._read = function() {
  var value = val++
  console.log('read', value)
  this.push(value)
}

var sink = new Writable({objectMode: true})

sink._write = function(chunk, enc, cb) {
  console.log('write', chunk)
  setTimeout(cb, 1000)
}

var batch = new Batch({size: 1000, highWaterMark: 1})

readable.pipe(batch).pipe(sink)
```

What I would expect from the code sample above is for at _most_ 2000 reads to happen before the slow writer receives a row, but if you run it it will read over 1,000,000 rows from the reader before hitting the writer.  :eyes: 

This commit adds support for back pressure by allowing the user to optionally specify a `highWaterMark` on the options which will be passed to the underlying Transform stream.  It's backwards compatible too! :clap: 

I also added some tests because...tests are cool. :sunglasses: 
