### PR TITLE
Allow instantiation without `new`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@ module.exports = BatchStream;
 
 
 function BatchStream (options) {
+  if (!(this instanceof BatchStream)) return new BatchStream(options);
+  
   options || (options = {});
 
   var transformOptions = {


### PR DESCRIPTION
Like is commonplace with lots of other stream modules, it would be nice to be able to instantiate `BatchStream` as if it was a normal function and not a constructor. Eg.

``` js
var batch = require('batch-stream');

var b1 = new batch({size: 5});
var b2 = batch({size: 5});
```

Examples of other modules supporting this functionality are [`concat-stream`](https://github.com/maxogden/concat-stream/blob/1f4ea1a7791b9366a133cab033eb0f3564cb0d92/index.js#L11) and all [`through2`](https://github.com/rvagg/through2/blob/ba4a87875f2c82323c10023e36f4ae4b386c1bf8/through2.js#L68-L69) streams (`through` only supports the "function" approach)
